### PR TITLE
Show `Start logging instance` only on debug level

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const { JSDOM } = jsdom;
 class Log {
   constructor(logLevel) {
     this.logLevel = logLevel;
-    console.log("Start logging instance");
+    this.debug("Start logging instance");
   }
 
   setLogLevel(pLogLevel) {


### PR DESCRIPTION
I want to write a simple script, where the output is parsed. So the `Start logging instance` log message is disturbs this.