### PR TITLE
fix never resolving promise and never ending log

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class Log {
       console.log("INFO:  " + pMessage);
     }
   }
-  
+
   warn(pMessage) {
     if (this.logLevel == "DEBUG" || this.logLevel == "INFO" || this.logLevel == "WARN")
     {
@@ -325,9 +325,10 @@ class VwWeConnect {
         // resolve only after all the different calls have finished reading their data
         // await promise at the end of this method
         let promise = new Promise((resolve, reject) => {
-            setInterval(() => {
+            const finishedReadingInterval = setInterval(() => {
                 if (this.finishedReading())
                 {
+                    clearInterval(finishedReadingInterval)
                     resolve("done!");
                 }
             }, 1000)
@@ -797,7 +798,7 @@ class VwWeConnect {
             );
         });
     }
-    
+
     receiveLoginUrl() {
         return new Promise((resolve, reject) => {
             request(
@@ -1202,7 +1203,7 @@ class VwWeConnect {
             );
         });
     }
-    
+
     getHomeRegion(vin) {
         return new Promise((resolve, reject) => {
             this.log.debug("START getHomeRegion");
@@ -1232,7 +1233,7 @@ class VwWeConnect {
                             this.log.error(JSON.stringify(body.error));
                             reject();
                         }
-                        this.log.debug("getHomeRegion vin[" + vin + "]: " + JSON.stringify(body));                        
+                        this.log.debug("getHomeRegion vin[" + vin + "]: " + JSON.stringify(body));
                         this.homeRegion[vin] = "https://msg.volkswagen.de";
                         if (body.homeRegion && body.homeRegion.baseUri && body.homeRegion.baseUri.content) {
                             if (body.homeRegion.baseUri.content !== "https://mal-1a.prd.ece.vwg-connect.com/api") {
@@ -1250,7 +1251,7 @@ class VwWeConnect {
             );
         });
     }
-    
+
     getCarData() {
         return new Promise((resolve, reject) => {
             this.log.debug("START getCarData");
@@ -1351,7 +1352,7 @@ class VwWeConnect {
                         this.log.debug("getVehicles: " + JSON.stringify(body));
                         this.vehicles = body;
                         this.boolFinishVehicles = true;
-                      
+
                         if (this.config.type === "id") {
                             body.data.forEach((element) => {
                                 const vin = element.vin;
@@ -1472,11 +1473,13 @@ class VwWeConnect {
                 this.boolFinishChargeAndPay = true;
             })
             .catch((hideError) => {
+                this.boolFinishChargeAndPay = true;
                 if (hideError) {
                     this.log.debug("Failed to get chargeandpay records");
                     return;
                 }
                 this.log.error("Failed to get chargeandpay records");
+
             });
         this.genericRequest("https://wecharge.apps.emea.vwapps.io/home-charging/v1/stations?limit=" + limit, header, "wecharge.homecharging.stations", [404], "result", "stations")
             .then((body) => {
@@ -1504,6 +1507,7 @@ class VwWeConnect {
                 });
             })
             .catch((hideError) => {
+                this.boolFinishStations = true;
                 if (hideError) {
                     this.log.debug("Failed to get stations");
                     return;
@@ -1524,6 +1528,7 @@ class VwWeConnect {
                 this.boolFinishHomecharging = true;
             })
             .catch((hideError) => {
+                this.boolFinishHomecharging = true;
                 if (hideError) {
                     this.log.debug("Failed to get records");
                     return;
@@ -1608,7 +1613,7 @@ class VwWeConnect {
                     this.log.debug("getIdStatus: " + JSON.stringify(body));
                     this.idData = body;
                     this.boolFinishIdData = true;
-                    
+
                     try {
                         const adapter = this;
                         traverse(body.data).forEach(function (value) {
@@ -1751,7 +1756,7 @@ class VwWeConnect {
             );
         });
     }
-    
+
     refreshIDToken() {
         return new Promise((resolve, reject) => {
             this.log.debug("Token Refresh started");
@@ -1813,7 +1818,7 @@ class VwWeConnect {
             );
         });
     }
-    
+
     getVehicleData(vin) {
         return new Promise((resolve, reject) => {
             if (this.config.type === "go") {
@@ -2378,7 +2383,7 @@ class VwWeConnect {
             );
         });
     }
-    
+
     setVehicleStatusv2(vin, url, body, contentType, secToken) {
         return new Promise((resolve, reject) => {
             url = this.replaceVarInUrl(url, vin);
@@ -2434,7 +2439,7 @@ class VwWeConnect {
             );
         });
     }
-    
+
     requestSecToken(vin, service) {
         return new Promise((resolve, reject) => {
             let url = "https://mal-1a.prd.ece.vwg-connect.com/api/rolesrights/authorization/v2/vehicles/" + vin + "/services/" + service + "/security-pin-auth-requested";
@@ -2540,7 +2545,7 @@ class VwWeConnect {
             );
         });
     }
-    
+
     generateSecurPin(challenge) {
         return new Promise((resolve, reject) => {
             if (!this.config.pin) {
@@ -2564,7 +2569,7 @@ class VwWeConnect {
                 });
         });
     }
-    
+
     getCodeChallenge() {
         let hash = "";
         let result = "";
@@ -2621,7 +2626,7 @@ class VwWeConnect {
         }
         return result;
     }
-    
+
     /**
      * Is called when adapter shuts down - callback has to be called under any circumstances!
      * @param {() => void} callback


### PR DESCRIPTION
Hi, 

when for example charge and pay is not available for a user (like me), then getData will never resolve its promise. 
In case of an error the bools need to set to true again, because the request was done. 

When `this.finishedReading()` returns true, the interval also needs to be cleared, otherwise it will end in an endless log loop.

cheers Steffen

