### PR TITLE
Introduce idCharger config type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ All methods work with promises.
 Login credentials. Pin is not needed for the ID connect, but probably for other car types.
 
 #### vwConn.setConfig(type)
-Set the login type. "id" for the ID series. Other possible values "vw", "skoda", "seat", "audi", "vwv2" and "go".
+Set the login type.
+- "id" for the ID series.
+- "idCharger" for ID Charger without an ID linked to the account.
+- Other possible values "vw", "skoda", "seat", "audi", "vwv2" and "go".
 
 #### vwConn.setLogLevel(logLevel)
 Set/change the log level to "DEBUG", "INFO" or "ERROR" (default).

--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ class VwWeConnect {
         numberOfTrips: 1,
         logLevel: "ERROR",
         targetTempC: -1,
-        targetSOC: -1
+        targetSOC: -1,
+        chargerOnly: false
     }
 
     currSession = {
@@ -145,7 +146,7 @@ class VwWeConnect {
                      " Stat: " + this.boolFinishStations +
                      /*" Car: " + this.boolFinishCarData*/
                      " Vehic: " + this.boolFinishVehicles);
-      return this.boolFinishIdData
+      return (this.boolFinishIdData || this.config.chargerOnly)
           && this.boolFinishHomecharging
           && this.boolFinishChargeAndPay
           && this.boolFinishStations
@@ -165,7 +166,15 @@ class VwWeConnect {
     }
 
     setConfig(pType) {
-        this.config.type = pType;
+        if (pType == "idCharger")
+        {
+          this.config.type = "id";
+          this.config.chargerOnly = true;
+        }
+        else
+        {
+          this.config.type = pType;
+        }
     }
 
     setActiveVin(pVin) {


### PR DESCRIPTION
New config type "idCharger" to avoid hanging when only a wallbox but no ID is linked to the used account.